### PR TITLE
handling attributes in JSX elements

### DIFF
--- a/crates/core/src/shared/transform.rs
+++ b/crates/core/src/shared/transform.rs
@@ -1,7 +1,7 @@
 use html_escape::decode_html_entities;
 use oxc::{
-    allocator::{Allocator, Vec as OxcVec},
-    ast::ast::{self, JSXElementName},
+    allocator::Vec as OxcVec,
+    ast::ast::{self},
     semantic::SymbolFlags,
     span::{Atom, SPAN},
 };
@@ -141,7 +141,7 @@ impl<'a> JsxTransform {
                     template: None,
                     exprs: ctx.ast.vec(),
                     text: false,
-                }
+                };
             }
         };
 
@@ -248,19 +248,14 @@ impl<'a> JsxTransform {
         children: &[ast::JSXChild<'a>],
         ctx: &mut TraverseCtx<'a>,
     ) -> String {
-        let mut child_tmpls = String::new();
         let info = TransformInfo::default();
-        for child in children {
-            match self.transform_node(child, ctx, &info) {
-                Some(child_result) => {
-                    if let Some(child_tmpl) = child_result.template {
-                        child_tmpls.push_str(&child_tmpl);
-                    }
-                }
-                None => {}
-            }
-        }
-        child_tmpls
+        children
+            .iter()
+            .filter_map(|child| {
+                self.transform_node(child, ctx, &info)
+                    .and_then(|child_result| child_result.template)
+            })
+            .collect::<String>()
     }
 }
 

--- a/crates/core/src/shared/transform.rs
+++ b/crates/core/src/shared/transform.rs
@@ -280,7 +280,7 @@ mod transform_tests {
     use super::*;
     use oxc::{allocator::Allocator, parser::Parser, semantic::SemanticBuilder, span::SourceType};
 
-    struct test_case {
+    struct TestCase {
         source: &'static str,
         expected_id: Option<Atom<'static>>,
         expected_template: Option<String>,
@@ -296,7 +296,7 @@ mod transform_tests {
                 var _tmpl$ = /*#__PURE__*/_$template(`<div class=test-class>Hello`); // <-
                 const foo = _tmpl$();
             */
-            test_case {
+            TestCase {
                 source: r#"<div class="test-class">Hello</div>"#,
                 expected_id: None,
                 expected_template: Some(r#"<div class=test-class>Hello"#.to_string()),
@@ -308,7 +308,7 @@ mod transform_tests {
                 var _tmpl$ = /*#__PURE__*/_$template(`<div>Hello`); // <-
                 const foo = _tmpl$();
             */
-            test_case {
+            TestCase {
                 source: r#"<div>Hello</div>"#,
                 expected_id: None,
                 expected_template: Some(r#"<div>Hello"#.to_string()),
@@ -320,7 +320,7 @@ mod transform_tests {
                 var _tmpl$ = /*#__PURE__*/_$template(`<span class=highlight>Text`); // <-
                 const foo = _tmpl$();
             */
-            test_case {
+            TestCase {
                 source: r#"<span class="highlight">Text</span>"#,
                 expected_id: None,
                 expected_template: Some(r#"<span class=highlight>Text"#.to_string()),

--- a/crates/core/src/shared/transform.rs
+++ b/crates/core/src/shared/transform.rs
@@ -132,9 +132,10 @@ impl<'a> JsxTransform {
         el: &ast::JSXElement<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> TransformResult<'a> {
-        let tag_name = match el.opening_element.name {
-            ast::JSXElementName::Identifier(ref ident) => ident.name.clone(),
+        let tag_name = match &el.opening_element.name {
+            ast::JSXElementName::Identifier(ident) => ident.name.clone(),
             _ => {
+                // TODO
                 return TransformResult {
                     id: None,
                     template: None,


### PR DESCRIPTION
# Description

* Handling of `class` Attribute in JSX Elements:
    - The `transform_element` function now extracts the `class` attribute from JSX elements and includes it in the generated HTML string.

* Handling Element without `class` Attribute:
    - when a `class` attribute is not exists, the function generates an HTML string that includes only the element tag and its content. (e.g., `<div>Hello`)

The expected value of the test used the client-side rendering result of SolidJS.