### PR TITLE
loosen napi test to only check basic functionality

### DIFF
--- a/crates/napi/tests/index.mjs
+++ b/crates/napi/tests/index.mjs
@@ -5,7 +5,9 @@ import assert from "node:assert";
 
 import { transform } from "../index.js";
 
-test("transform works", (t) => {
-	const source = "const Comp = () => <div>Hello, world!</div>;";
-	assert.strictEqual(transform(source).trim(), source);
+test("transform() returns compiled code", (t) => {
+	assert.strictEqual(
+		typeof transform("const Comp = () => <div>Hello, world!</div>;"),
+		"string",
+	);
 });


### PR DESCRIPTION
Since the core logic is tested with Rust integration tests in Core, it'd be enough for now to test only that the bindings are working without crashing.